### PR TITLE
Add libunity and deps to build

### DIFF
--- a/org.gnome.Geary.json
+++ b/org.gnome.Geary.json
@@ -33,6 +33,9 @@
         "--talk-name=org.gnome.ControlCenter",
         "--talk-name=org.gnome.OnlineAccounts",
 
+        /* Unity launcher access */
+        "--talk-name=com.canonical.Unity",
+
         /* Needed for dconf to work */
         "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
@@ -100,6 +103,48 @@
                 }
             ]
         },
+        /* Start of Unity launcher badge support */
+        {
+            "name" : "libdee",
+            "build-options" : {
+                "cflags" : "-Wno-error=misleading-indentation"
+            },
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://launchpad.net/dee/1.0/1.2.7/+download/dee-1.2.7.tar.gz",
+                    "md5" : "b92f27f0a99cac24c2128880601bb7d7"
+                }
+            ]
+        },
+        {
+            "name" : "libdbusmenu",
+            "config-opts" : [
+                "--enable-gtk",
+                "--disable-dumper"
+            ],
+            "make-install-args" : [
+                "typelibdir=/app/lib/girepository-1.0"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://launchpad.net/libdbusmenu/16.04/16.04.0/+download/libdbusmenu-16.04.0.tar.gz",
+                    "md5" : "3c05d53053b3ea69384b5f93d7a4c7c4"
+                }
+            ]
+        },
+        {
+            "name" : "libunity",
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/libunity/7.1.4+16.04.20180209.1-0ubuntu1/libunity_7.1.4+16.04.20180209.1.orig.tar.gz",
+                    "sha256" : "d4013500c0a972ecea5ba26e3567ee5d4c3eae481281badbbbe3cbaeab5f389b"
+                }
+            ]
+        },
+        /* End of deps for Unity launcher badge support */
         {
             "name": "geary",
             "buildsystem": "meson",


### PR DESCRIPTION
Libunity is used by Ubuntu, Elementary and other distros to add
notification bubbles to launchers indicating unread message count.

Fixes #13