### PR TITLE
Add patch for missing Message-ID header

### DIFF
--- a/org.gnome.Geary.yaml
+++ b/org.gnome.Geary.yaml
@@ -206,3 +206,5 @@ modules:
         sha256: 8e26aaf9dc1d0112da4a7b6d636721c09adc9458f1aee92e93cd324f42e0bdf6
       - type: patch
         path: patches/0001-desktop-org.gnome.Geary.appdata.xml.in.in-Update-for.patch
+      - type: patch
+        path: patches/0001-Geary.RFC822.Message-Fix-Message-Id-header-not-being.patch

--- a/patches/0001-Geary.RFC822.Message-Fix-Message-Id-header-not-being.patch
+++ b/patches/0001-Geary.RFC822.Message-Fix-Message-Id-header-not-being.patch
@@ -1,0 +1,127 @@
+From b394ced805ea9fe537a0740c75f33dcd6933d086 Mon Sep 17 00:00:00 2001
+From: Michael Gratton <mike@vee.net>
+Date: Wed, 25 Mar 2020 13:00:56 +1100
+Subject: [PATCH] Geary.RFC822.Message: Fix Message-Id header not being set
+
+The port to GMime 3 missed setting the Message-Id header on the
+underlying GMime Message object when constructing a message, from a
+ComposedEmail, so this was not getting set on outoging email.
+
+Fixes #758
+---
+ src/engine/rfc822/rfc822-message.vala | 20 ++++++-----
+ test/engine/rfc822-message-test.vala  | 48 +++++++++++++++++++++++++++
+ 2 files changed, 60 insertions(+), 8 deletions(-)
+
+diff --git a/src/engine/rfc822/rfc822-message.vala b/src/engine/rfc822/rfc822-message.vala
+index df65b932..1ee7b698 100644
+--- a/src/engine/rfc822/rfc822-message.vala
++++ b/src/engine/rfc822/rfc822-message.vala
+@@ -130,19 +130,22 @@ public class Geary.RFC822.Message : BaseObject, EmailHeaderSet {
+         this.message = new GMime.Message(true);
+ 
+         // Required headers
+-        assert(email.from.size > 0);
+-        this.sender = email.sender;
++
+         this.from = email.from;
+-        this.date = email.date;
++        foreach (RFC822.MailboxAddress mailbox in email.from) {
++            this.message.add_mailbox(FROM, mailbox.name, mailbox.address);
++        }
+ 
++        this.date = email.date;
+         this.message.set_date(this.date.value);
+-        
+-        if (email.from != null) {
+-            foreach (RFC822.MailboxAddress mailbox in email.from)
+-                this.message.add_mailbox(FROM, mailbox.name, mailbox.address);
+-        }
++
++        // Not actually required, but effectively required since
++        // otherwise mail servers will treat email as spam
++        this.message_id = new MessageID(message_id);
++        this.message.set_message_id(message_id);
+ 
+         // Optional headers
++
+         if (email.to != null) {
+             this.to = email.to;
+             foreach (RFC822.MailboxAddress mailbox in email.to)
+@@ -162,6 +165,7 @@ public class Geary.RFC822.Message : BaseObject, EmailHeaderSet {
+         }
+ 
+         if (email.sender != null) {
++            this.sender = email.sender;
+             this.message.add_mailbox(SENDER, this.sender.name, this.sender.address);
+         }
+ 
+diff --git a/test/engine/rfc822-message-test.vala b/test/engine/rfc822-message-test.vala
+index ddb767d5..48b4bef0 100644
+--- a/test/engine/rfc822-message-test.vala
++++ b/test/engine/rfc822-message-test.vala
+@@ -58,6 +58,7 @@ This is the second line.
+         add_test("get_searchable_body", get_searchable_body);
+         add_test("get_searchable_recipients", get_searchable_recipients);
+         add_test("get_network_buffer", get_network_buffer);
++        add_test("from_composed_email", from_composed_email);
+         add_test("from_composed_email_inline_attachments", from_composed_email_inline_attachments);
+     }
+ 
+@@ -213,6 +214,53 @@ This is the second line.
+         assert_true(buffer.to_string() == NETWORK_BUFFER_EXPECTED, "Network buffer differs");
+     }
+ 
++    public void from_composed_email() throws GLib.Error {
++        RFC822.MailboxAddress to = new RFC822.MailboxAddress(
++            "Test", "test@example.com"
++        );
++        RFC822.MailboxAddress from = new RFC822.MailboxAddress(
++            "Sender", "sender@example.com"
++        );
++       Geary.ComposedEmail composed = new Geary.ComposedEmail(
++            new GLib.DateTime.now_local(),
++            new Geary.RFC822.MailboxAddresses.single(from)
++       ).set_to(new Geary.RFC822.MailboxAddresses.single(to));
++       composed.body_text = "hello";
++
++        this.message_from_composed_email.begin(
++            composed,
++            async_complete_full
++        );
++        Geary.RFC822.Message message = message_from_composed_email.end(async_result());
++
++        assert_non_null(message.to, "to");
++        assert_non_null(message.from, "from");
++        assert_non_null(message.date, "date");
++        assert_non_null(message.message_id, "message_id");
++
++        string message_data = message.to_string();
++        assert_true(
++            message_data.contains("To: Test <test@example.com>\n"),
++            "to data"
++        );
++        assert_true(
++            message_data.contains("From: Sender <sender@example.com>\n"),
++            "from data"
++        );
++        assert_true(
++            message_data.contains("Message-Id: "),
++            "message-id data"
++        );
++        assert_true(
++            message_data.contains("Date: "),
++            "date data"
++        );
++        assert_true(
++            message_data.contains("hello\n"),
++            "body data"
++        );
++    }
++
+     public void from_composed_email_inline_attachments() throws Error {
+         RFC822.MailboxAddress to = new RFC822.MailboxAddress(
+             "Test", "test@example.com"
+-- 
+2.25.1
+


### PR DESCRIPTION
This is serious enough to warrant patchign ahead of .1 coming out next week.