### PR TITLE
org.gnome.Geary.yaml: Workaround for WebKitGTK not printing under Flatpak

### DIFF
--- a/org.gnome.Geary.yaml
+++ b/org.gnome.Geary.yaml
@@ -53,7 +53,10 @@ finish-args:
   # Migrate GSettings into the sandbox
   - "--metadata=X-DConf=migrate-path=/org/gnome/Geary/"
 
-  # Let view source keep on working as-sis for now. Bug 779311. */
+  # Workaround for printing to PDF until WebKitGTK supports printing
+  - "--filesystem=xdg-download:rw"
+
+  # Let view source keep on working as-sis for now. Bug 779311.
   - "--filesystem=/tmp"
 
 cleanup:


### PR DESCRIPTION
Since WebKitGTK does not currently support printing under Flatpak,
enable RW access to XDG downloads folder, so at least people can print
to a PDF, then print that.

See https://github.com/flathub/org.gnome.Geary/issues/42