### PR TITLE
Work around password lookup hang when sandboxed

### DIFF
--- a/org.gnome.Geary.yaml
+++ b/org.gnome.Geary.yaml
@@ -178,6 +178,14 @@ modules:
       - "--disable-null"
       - "--disable-oss"
 
+  # Geary dependency, workaround libsecret access via secret portal
+  # being non-functional GNOME/libsecret#58
+  - name: libsecret
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/libsecret/0.19/libsecret-0.19.1.tar.xz
+        sha256: 8583e10179456ae2c83075d95455f156dc08db6278b32bf4bd61819335a30e3a
+
   # Geary dependency
   - name: gsound
     sources:


### PR DESCRIPTION
Libsecret 0.20's portal support is completely hosed at the moment.
Ship 0.19 until that is resolved.

See:

 * https://gitlab.gnome.org/GNOME/libsecret/-/issues/58
 * https://gitlab.gnome.org/GNOME/geary/-/issues/1147