### PR TITLE
org.gnome.Geary.yaml: Fix EDS contacts not working under flatpak, again

### DIFF
--- a/org.gnome.Geary.yaml
+++ b/org.gnome.Geary.yaml
@@ -46,8 +46,7 @@ finish-args:
   - "--talk-name=org.gnome.OnlineAccounts"
 
   # Folks contact and avatar support (via EDS)
-  - "--talk-name=org.gnome.evolution.dataserver.AddressBook10"
-  - "--talk-name=org.gnome.evolution.dataserver.Sources5"
+  - "--talk-name=org.gnome.evolution.dataserver.*"
   - "--filesystem=xdg-cache/evolution/addressbook:ro"
 
   # Migrate GSettings into the sandbox


### PR DESCRIPTION
Stop trying to chase EDS DBus versioning, just allow access to any
EDS endpoint.