### PR TITLE
Fix configuration directory being read-only

### DIFF
--- a/org.gnome.Geary.yaml
+++ b/org.gnome.Geary.yaml
@@ -54,7 +54,6 @@ finish-args:
 
   # Migrate Geary settings from other release versions
   - "--filesystem=~/.config/geary:ro"
-  - "--filesystem=~/.var/app/org.gnome.Geary/config/geary:ro"
 
   # Workaround for printing to PDF until WebKitGTK supports printing
   - "--filesystem=xdg-download:rw"


### PR DESCRIPTION
So, I just installed Geary from Flathub on my new Fedora Silverblue system, and I had my problems configuring any account, no matter if from GNOME's Online Accounts or from the internal "Create Account" System.

A quick look with Flatseal showed that the config directory for the Flatpak is set to read only, which results in Geary not able to save it's config files.

This removes the line that is responsible for it, so you can actually use Geary.