### PR TITLE
build: Delete libsecret

### DIFF
--- a/org.gnome.Geary.yaml
+++ b/org.gnome.Geary.yaml
@@ -172,14 +172,6 @@ modules:
   # GSound dependency
   - shared-modules/libcanberra/libcanberra.json
 
-  # Geary dependency, workaround libsecret access via secret portal
-  # being non-functional GNOME/libsecret#58
-  - name: libsecret
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/libsecret/0.19/libsecret-0.19.1.tar.xz
-        sha256: 8583e10179456ae2c83075d95455f156dc08db6278b32bf4bd61819335a30e3a
-
   # Geary dependency
   - name: gsound
     buildsystem: meson


### PR DESCRIPTION
Deleted `libsecret`. (already in runtime)